### PR TITLE
fix "Duplicate node name in graph" issue

### DIFF
--- a/lookahead_tensorflow.py
+++ b/lookahead_tensorflow.py
@@ -75,7 +75,9 @@ class Lookahead(optimizer.Optimizer):
         return self.optimizer._resource_apply_sparse(grad, var, indices)
 
     def _finish(self, update_ops, name_scope):
-        inner_finish_op = self.optimizer._finish(update_ops, name_scope)
+        # fix "Duplicate node name in graph" issue
+        # inner_finish_op = self.optimizer._finish(update_ops, name_scope)
+        inner_finish_op = self.optimizer._finish(update_ops, name_scope+self.optimizer._name+'/')
 
         with ops.control_dependencies([inner_finish_op, ]):
             la_step = self._get_la_step_accumulators()


### PR DESCRIPTION
When I use this `Lookahead()` function, tensorflow throw an error:
`InvalidArgumentError: Duplicate node name in graph: 'train_step/Lookahead'`
After digging into the code, I found the same name scope will use twice, this cause the name of node duplicated. 
The solution is to append the `self.optimizer._name` to the name scope to prevent name duplicate. Because the `self.optimizer._name` is the name of optimizer which passed into `Lookahead()`, it should not duplicate at all.
