### PR TITLE
Update lookahead_pytorch.py

### DIFF
--- a/lookahead_pytorch.py
+++ b/lookahead_pytorch.py
@@ -90,10 +90,11 @@ class Lookahead(Optimizer):
         if self._la_step >= self._total_la_steps:
             self._la_step = 0
             # Lookahead and cache the current optimizer parameters
+            device = "cuda" if torch.cuda.is_available() else "cpu"
             for group in self.optimizer.param_groups:
                 for p in group['params']:
                     param_state = self.state[p]
-                    p.data.mul_(self.la_alpha).add_(param_state['cached_params'], alpha=1.0 - self.la_alpha)  # crucial line
+                    p.data.mul_(self.la_alpha).add_(param_state['cached_params'].to(device), alpha=1.0 - self.la_alpha)  # crucial line
                     param_state['cached_params'].copy_(p.data)
                     if self.pullback_momentum == "pullback":
                         internal_momentum = self.optimizer.state[p]["momentum_buffer"]


### PR DESCRIPTION
move param_state['cached_params'] to device (cuda or cpu) to avoid having tensors on two different deviced (cuda, cpu)
If not 
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
can occur